### PR TITLE
Fix null reference for call to `get_class` in `design/admin/template/content/browse_mode_list.tpl`

### DIFF
--- a/design/admin/templates/content/browse_mode_list.tpl
+++ b/design/admin/templates/content/browse_mode_list.tpl
@@ -69,7 +69,7 @@
             {if and( or( eq( $browse.action_name, 'MoveNode' ), eq( $browse.action_name, 'CopyNode' ), eq( $browse.action_name, 'AddNodeAssignment' ) ), $Nodes.item.object.content_class.is_container|not )}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />
             {elseif and( eq( $browse.action_name, 'SwapNode' ),
-                         eq( get_class( $swap_node ), 'ezcontentobjecttreenode' ),
+                         cond( $swap_node, eq( get_class( $swap_node ), 'ezcontentobjecttreenode' ), false() ),
                          or( and( $swap_node.children_count|gt(0), $Nodes.item.object.content_class.is_container|not ),
                              and( $swap_node.is_container|not, $Nodes.item.children_count|gt(0) ) ) )}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />


### PR DESCRIPTION
`$swap_node` can intentionally be `NULL`. This causes `get_class` to return a `E_WARNING` as per PHP 7.2.
Making the call to `get_class` conditional on `$swap_nodes` existence fixes the issue.

Ref: https://www.php.net/manual/en/function.get-class.php